### PR TITLE
Make host port configurable

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -55,12 +55,15 @@ func WithLogger(logger func(format string, a ...any)) func(*Connection) {
 
 // Creates a new connection to a RCT device at the given address.
 // Must not be called concurrently.
-func NewConnection(ctx context.Context, host string, opt ...func(*Connection)) (*Connection, error) {
+func NewConnection(ctx context.Context, host string, port string, opt ...func(*Connection)) (*Connection, error) {
 	conn := &Connection{
 		cache:  newCache(),
 		broker: internal.NewBroker[*Datagram](),
 	}
 
+	if port == "" {
+		port = "8899"
+	}
 	for _, o := range opt {
 		o(conn)
 	}
@@ -68,7 +71,7 @@ func NewConnection(ctx context.Context, host string, opt ...func(*Connection)) (
 	bufC := make(chan byte, 1024)
 	errC := make(chan error, 1)
 
-	go conn.receive(ctx, net.JoinHostPort(host, "8899"), bufC, errC)
+	go conn.receive(ctx, net.JoinHostPort(host, port), bufC, errC)
 
 	// wait up to SuccessTimeout for first non-error response, i.e. successful read
 	var lastErr error

--- a/connection.go
+++ b/connection.go
@@ -55,15 +55,12 @@ func WithLogger(logger func(format string, a ...any)) func(*Connection) {
 
 // Creates a new connection to a RCT device at the given address.
 // Must not be called concurrently.
-func NewConnection(ctx context.Context, host string, port string, opt ...func(*Connection)) (*Connection, error) {
+func NewConnection(ctx context.Context, addr string, opt ...func(*Connection)) (*Connection, error) {
 	conn := &Connection{
 		cache:  newCache(),
 		broker: internal.NewBroker[*Datagram](),
 	}
 
-	if port == "" {
-		port = "8899"
-	}
 	for _, o := range opt {
 		o(conn)
 	}
@@ -71,7 +68,7 @@ func NewConnection(ctx context.Context, host string, port string, opt ...func(*C
 	bufC := make(chan byte, 1024)
 	errC := make(chan error, 1)
 
-	go conn.receive(ctx, net.JoinHostPort(host, port), bufC, errC)
+	go conn.receive(ctx, addr, bufC, errC)
 
 	// wait up to SuccessTimeout for first non-error response, i.e. successful read
 	var lastErr error


### PR DESCRIPTION
I'd like to make the host port for RCT configurable in EVCC. While the inverter itself always exposes the port 8899, I've been looking into creating a proxy server with caching to better handle multiple connections, e.g. from EVCC and Home Assistant.

Port 8899 is blocked by EVCC itself for the modbus proxy, so I can't bind the proxy server to that port.